### PR TITLE
Add priorities for `/usr/bin` and `/bin` directories

### DIFF
--- a/_str_func.c
+++ b/_str_func.c
@@ -1,0 +1,20 @@
+#include "main.h"
+
+/**
+ * _atoi - Convert string to integer
+ * @a: The string to convert
+ * Return: The integer value, or -1 if invalid input
+ */
+int _atoi(char *a)
+{
+	int integer = 0;
+
+	while (*a)
+	{
+		if (*a < '0' || *a > '9')
+			return (-1);
+		integer = integer * 10 + (*a - '0');
+		a++;
+	}
+	return (integer);
+}

--- a/_string_func.c
+++ b/_string_func.c
@@ -12,7 +12,7 @@
 
 char *p_concat(char *path, char *command)
 {
-	char *new_str = malloc(sizeof(char) * (_strlen(path) + _strlen(command) + 1));
+	char *new_str = malloc(sizeof(char) * (_strlen(path) + _strlen(command) + 2));
 	int i = 0, j = 0;
 
 	while (path[i])
@@ -21,12 +21,12 @@ char *p_concat(char *path, char *command)
 		i++;
 	}
 
-	new_str[i] += '/';
+	new_str[i] = '/';
 	i++;
 
 	while (command[j])
 	{
-		new_str[i] += command[j];
+		new_str[i] = command[j];
 		i++;
 		j++;
 	}
@@ -113,31 +113,12 @@ char  *s_concat(char *str1, char *str2)
  */
 int _strcmp(const char *i, const char *j)
 {
-    while (*i && *j)
-    {
-        if (*i != *j)
-            return 0;
-        i++;
-        j++;
-    }
-    return (*i == *j);
-}
-
-/**
- * _atoi - Convert string to integer
- * @str: The string to convert
- * Return: The integer value, or -1 if invalid input
- */
-int _atoi(char *a)
-{
-    int integer = 0;
-
-    while (*a)
-    {
-        if (*a < '0' || *a > '9')
-            return (-1);
-        integer = integer * 10 + (*a - '0');
-        a++;
-    }
-    return (integer);
+	while (*i && *j)
+	{
+		if (*i != *j)
+			return (0);
+		i++;
+		j++;
+	}
+	return (*i == *j);
 }

--- a/exit.c
+++ b/exit.c
@@ -7,5 +7,5 @@
  */
 void built_in_exit(void)
 {
-    _exit(EXIT_SUCCESS);
+	_exit(EXIT_SUCCESS);
 }

--- a/misc_func.c
+++ b/misc_func.c
@@ -16,12 +16,15 @@ char *path(char *input)
 	char *path_arr_cpy = strdup(path_arr);
 	struct stat file_exist;
 	char bash_variables[] = {'.', '/', '~'};
+	char bin_path[][PATH_MAX] = {"/usr/bin/", "/bin/"};
 	size_t i = 0;
-
 	char *p_part = strtok(path_arr_cpy, delim);
 
-	t_path = cmd;
+	for (i = 0; bin_path[i]; i++)
+		if (stat(s_concat(bin_path[i], cmd), &file_exist) == 0)
+			return (s_concat(bin_path[i], cmd));
 
+	t_path = cmd;
 	while (p_part)
 	{
 		char *fp_cmd = p_concat(p_part, cmd);
@@ -35,15 +38,9 @@ char *path(char *input)
 		p_part = strtok(NULL, delim);
 	}
 
-	while (bash_variables[i])
-	{
+	for (i = 0; bash_variables[i]; i++)
 		if (bash_variables[i] == tf_cmd[0])
-		{
 			t_path = resolve_r_path(cmd);
-		}
-
-		i++;
-	}
 
 	return (t_path);
 }
@@ -77,6 +74,9 @@ char *resolve_r_path(char *input)
 
 	realpath(input, fr_path);
 
+	free(input_cpy);
+	free(home_arr_cpy);
+
 	return (fr_path);
 }
 
@@ -100,7 +100,7 @@ char **get_arguments(char *input)
 	while (p_args)
 	{
 		j = _strlen(p_args);
-		args[i] = malloc(sizeof(char) * (j + 1));
+		args[i] = malloc(sizeof(char) * PATH_MAX);
 		if (!args[i])
 		{
 			free(args);
@@ -116,7 +116,6 @@ char **get_arguments(char *input)
 				break;
 			}
 		}
-
 		strncpy(args[i], p_args, j);
 		args[i][j] = '\0';
 


### PR DESCRIPTION
Since the `/usr/bin` and `/bin` directories store most of the executables, I have given them priority.
